### PR TITLE
Rounding errors on acos(alpha)

### DIFF
--- a/las_extractor/util/point_cloud_profiler.py
+++ b/las_extractor/util/point_cloud_profiler.py
@@ -116,6 +116,12 @@ def pointCloudExtractorV2(coordinates, bufferSizeMeter, outputDir, dataDir, json
                     yOB = p.y - seg['y1']
                     hypo = math.sqrt(xOB * xOB + yOB * yOB)
                     cosAlpha = (xOA * xOB + yOA * yOB)/(math.sqrt(xOA * xOA + yOA * yOA) * hypo)
+                    # Correct rounding errors:
+                    if cosAlpha > 1:
+                        cosAlpha = 1
+                    if cosAlpha < -1:
+                        cosAlpha = -1
+
                     alpha = math.acos(cosAlpha)
                     normalPointToLineDistance = math.sin(alpha) * hypo
                     # Filter for normal distance smaller or equal to buffer size


### PR DESCRIPTION
I do not know how I managed that... But the query hereunder, we get an error 500 because `cosAlpha` is greater then `1`, which is out of the boundaries of the `acos` function (`[-1, 1]`)

In the case hereunder, cosAlpha is equal to `1.0000000000002`...

https://sitnssl.ne.ch/las_extractor/lidar/profile?code=utrges43&geom={%22type%22%3A%22LineString%22%2C%22coordinates%22%3A[[555898%2C202034.5]%2C[555922%2C202010.5]]}&dataType=standard&callback=Ext.ux.JSONP.callback

@monodo, could please review this PR ?